### PR TITLE
Fix activation fatal error and bump version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/) and follows t
 
 ---
 
+## [1.0.1] = 2025-08-13
+
+### Fixed
+- Fatal error when activating plugin caused by calling a non-static method `create_table()` statically in `Loader::activate()` - [Issue #2](https://github.com/smuddin/wp-boilerplate-plugin/issues/2).
+
+
+---
+
 ## [1.0.0] = 2025-08-12
 
 ### Added

--- a/my-plugin.php
+++ b/my-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name:       My Plugin
  * Plugin URI:        https://github.com/smuddin/woocommerce-bookstore
  * Description:       Write a proper description of your plugin here.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            SM Uddin
  * Author URI:        https://arifuddin.xyz/
  * Requires Plugins:  woocommerce

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -40,7 +40,7 @@ class Loader
     {
     }
 
-    private function create_table()
+    private static function create_table()
     {
         global $wpdb;
         

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,7 +7,7 @@ defined( 'ABSPATH' ) || exit;
 final class Plugin
 {
     public const NAME    = 'My Plugin';
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.0.1';
     public const DOMAIN  = 'my-plugin';
 
     private function __construct() {}


### PR DESCRIPTION
Resolved a fatal error during plugin activation by making Loader::create_table() static. Updated plugin version to 1.0.1 and documented the fix in CHANGELOG.md.